### PR TITLE
make varchar user-configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ target-db2 --about --format=markdown
 | user | True     | None    | IBM Db2 Database User Name |
 | password | True     | None    | IBM Db2 Database User Password |
 | database | True     | None    | IBM Db2 Database Name |
+| varchar_size | False    | None    | Field size for Varchar type. Default 10000. <BR/>Since JSON values are serialized to varchar, <BR/>it may be necessary to increase this value. <BR/>Max possible value 32764 |
 | add_record_metadata | False    | None    | Add metadata to records. |
 | load_method | False    | TargetLoadMethods.APPEND_ONLY | The method to use when loading data into the destination. `append-only` will always write all input records whether that records already exists or not. `upsert` will update existing records and insert new records. `overwrite` will delete all existing records and insert all input records. |
 | batch_size_rows | False    | None    | Maximum number of rows in each batch. |
@@ -106,9 +107,6 @@ environment variable is set either in the terminal context or in the `.env` file
 
 ### Db2 Authentication and Authorization
 
-<!--
-Developer TODO: If your target requires special access on the destination system, or any special authentication requirements, provide those here.
--->
 
 Currently, only username / password (UID / PWD) based authentication is supported. If you need support for additional authentication mechanisms, please open an issue.
 

--- a/target_db2/connector.py
+++ b/target_db2/connector.py
@@ -250,7 +250,8 @@ class DB2Connector(SQLConnector):
         is_primary_key: bool = False,  # noqa: FBT001, FBT002
     ) -> sa.types.TypeEngine:
         """Convert JsonSchema to IBM Db2 data type."""
-        string_length = MAX_PK_STRING_SIZE if is_primary_key else MAX_VARCHAR_SIZE
+        varchar_size = self.config.get("varchar_size", MAX_VARCHAR_SIZE)
+        string_length = MAX_PK_STRING_SIZE if is_primary_key else varchar_size
         if _jsonschema_type_check(jsonschema_type, ("string",)):
             datelike_type = get_datelike_property_type(jsonschema_type)
             if not datelike_type and "maxLength" not in jsonschema_type:
@@ -258,7 +259,7 @@ class DB2Connector(SQLConnector):
         is_obj = _jsonschema_type_check(jsonschema_type, ("object",))
         is_arr = _jsonschema_type_check(jsonschema_type, ("array",))
         if is_obj or is_arr:
-            return JSONVARCHAR(MAX_VARCHAR_SIZE)
+            return JSONVARCHAR(varchar_size)
         return super(DB2Connector, DB2Connector).to_sql_type(jsonschema_type)
 
     def create_empty_table(  # noqa: PLR0913

--- a/target_db2/target.py
+++ b/target_db2/target.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from textwrap import dedent
+
 from singer_sdk import typing as th
 from singer_sdk.target_base import Target
 
@@ -46,6 +48,18 @@ class TargetDb2(Target):
             th.StringType,
             required=True,
             description="IBM Db2 Database Name",
+        ),
+        th.Property(
+            "varchar_size",
+            th.IntegerType,
+            description=dedent(
+                """
+                Field size for Varchar type. Default 10000.
+                Since JSON values are serialized to varchar,
+                it may be necessary to increase this value.
+                Max possible value 32764
+                """
+            ).strip(),
         ),
     ).to_dict()
 


### PR DESCRIPTION
# Description

Add a parameter `varchar_size` to the target's settings. This enables the user to specify the default size with which varchar fields get created on the database.