### PR TITLE
finalize release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,19 @@
-name: Release
+name: Release (build & publish to PyPI)
 
 on:
   push:
-
-permissions:
-  contents: write  # Needed to upload artifacts to the release
-  id-token: write  # Needed for OIDC PyPI publishing
+    branches:
+      - main
 
 jobs:
   build:
+    name: "Build wheel & sdist"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        ref: ${{ github.ref }}
     - uses: hynek/build-and-inspect-python-package@v2
 
   publish:
@@ -23,15 +23,23 @@ jobs:
     ## TODO: optionally provide the name of the environment for the trusted
     ## publisher on PyPI
     ## https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
-    # environment: pypi
+    environment:
+      name: release
+      url: https://pypi.org/p/target-db2
+    permissions:
+      id-token: write
+      contents: write
+
     if: startsWith(github.ref, 'refs/tags/')
+
     steps:
+
     - uses: actions/download-artifact@v4
       with:
         name: Packages
         path: dist
-    - name: Upload wheel to release
-      uses: svenstaro/upload-release-action@v2
+
+    - uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{secrets.GITHUB_TOKEN}}
         file: dist/*.whl
@@ -39,7 +47,4 @@ jobs:
         overwrite: true
         file_glob: true
 
-    - name: Publish
-      ## TODO: create a trusted publisher on PyPI
-      ## https://docs.pypi.org/trusted-publishers/
-      uses: pypa/gh-action-pypi-publish@v1.9.0
+    - uses: pypa/gh-action-pypi-publish@v1.9.0


### PR DESCRIPTION
# Description

Set up a release workflow using github actions.

1. **build** build the wheel and source distribution as github artifacts
2. **publish** downloads the wheel artifacts and publishes to pypi.

The workflow is triggered on a push to the main branch if the commit is tagged