### PR TITLE
remove mention of branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Release (build & publish to PyPI)
 
 on:
   push:
-    branches:
-      - main
 
 jobs:
   build:


### PR DESCRIPTION
# Description

The release workflow was not triggered when I did the following

```bash
git checkout main
git pull
git tag -a 0.1.0a
git push tags --follow-tags
```
I suspect that `on: push: branch: main` is not working well with `if github.ref starts with refs/tags/` condition. On several how-to's, it is suggested to only use the `github.ref`.