### PR TITLE
fix issues with quoting, logging and bump minor version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,6 +38,7 @@ services:
       - db2
     environment:
     - DB2HOST=db2
+    - MELTANO_ENVIRONMENT=docker
     volumes:
     - type: bind
       source: ./meltano-state

--- a/meltano.yml
+++ b/meltano.yml
@@ -43,10 +43,11 @@ plugins:
       public-test_table:
         replication-method: INCREMENTAL
         replication-key: updated_at
+        key-properties: [id]
   loaders:
   - name: target-db2
     namespace: target_db2
-    pip_url: target-db2
+    pip_url: -e .
     config:
       host: db2
       port: 50000

--- a/meltano.yml
+++ b/meltano.yml
@@ -1,11 +1,31 @@
 version: 1
 send_anonymous_usage_stats: true
 project_id: target-db2
-state_backend:
-  uri: file:///meltano-state/state
-default_environment: test
+
+default_environment: local
+
+
 environments:
-- name: test
+- name: local
+  config:
+    state_backend:
+      url: ./local-state/state
+
+    plugins:
+      extractors:
+      - name: tap-postgres
+        config:
+          host: localhost
+      loaders:
+        - name: target-db2
+          config:
+            host: localhost
+
+- name: docker
+  config:
+    state_backend:
+      url: file:///meltano-state/state
+
 plugins:
   extractors:
   - name: tap-postgres

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "target-db2"
-version = "0.0.1"
+version = "0.1.0"
 description = "`target-db2` is a Singer target for db2, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Haleemur Ali <haleemur@infostrux.com>"]

--- a/target_db2/connector.py
+++ b/target_db2/connector.py
@@ -111,7 +111,7 @@ class DB2Connector(SQLConnector):
                 column_type,
             ),
         )
-        compiled = create_column_clause.compile(self._engine)
+        compiled = create_column_clause.compile(self._engine).string
         return sa.DDL(
             "ALTER TABLE %(table_name)s ADD COLUMN %(create_column_clause)s",
             {  # type: ignore[arg-type]

--- a/target_db2/connector.py
+++ b/target_db2/connector.py
@@ -575,5 +575,5 @@ class Db2Sink(SQLSink):
     def generate_drop_table_statement(self, table_name: str) -> Executable:
         """Drop a table."""
         quoted_name = self.connector.quote(table_name)
-        self.logger.info("Dropping Table %(quoted_name)s", quoted_name)
+        self.logger.info("Dropping Table %s", quoted_name)
         return sa.text(f"DROP TABLE {quoted_name}")


### PR DESCRIPTION
Fix edge cases in db2 specific field quoting.

Add test to ensure alter table add column generates expected quoting behavior for fields starting with underscore.

non-core changes: dev environment separation `local` vs `docker` (in meltano.yml , the local environment allows the developer to run the package locally with databases that are expected on localhost, while the docker environment allows integration testing using the sample service specification in docker-compose.yml)