### PR TITLE
remove classifiers not accepted by PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,6 @@ keywords = [
 ]
 classifiers = [
     "Intended Audience :: Developers",
-    "Intended Audience :: Data Engineers",
-    "Intended Audience :: Data Scientists",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
# Description

It turns out these are not valid classifiers, and they prevent publishing to PyPI.

```
Intended Audience :: Data Scientist
Intended Audience :: Data Engineer
```