### PR TITLE
Upgrade sdk version

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,29 @@ Currently, only username / password (UID / PWD) based authentication is supporte
 
 The username & password can be provided through `meltano.yml` or the `target-db2`'s config.json. The user must have the following permissions in order to be able to load data into Db2.
 
-* TODO: figure out the minimal permissions requied by meltano to load data to Db2.
+## Minimal Permissions Required on DB2
+
+This library will perform the following actions on DB2.
+
+* CREATE TABLE
+* DROP TABLE
+* ALTER TABLE ADD COLUMN
+* ALTER TABLE ALTER COLUMN
+* INSERT INTO TABLE
+* MERGE INTO TABLE USING
+* [OPTIONALLY] CREATE SCHEMA
+
+_NOTE: `CREATE SCHEMA` is used to create a new schema where data will be loaded. If the stated target_schema, specified via `default_target_schema` exists, this library will not issue a `CREATE SCHEMA` command_
+
+## Known Limitations & Issues
+
+### Complex Data Structures (arrays & maps)
+
+Complex values such as `dict` or `list` will be json encoded and stored as `VARCHAR`. The `VARCHAR` column has a default size of 10000, and it is user configurable via the setting `varchar_size`.
+
+IBM Db2 allows VARCHAR columns up to 32704 bytes.
+
+This target currently does not write to CLOB fields, PRs welcome!
 
 ## Usage
 
@@ -187,28 +209,3 @@ docker compose down
 
 See the [dev guide](https://sdk.meltano.com/en/latest/dev_guide.html) for more instructions on how to use the Meltano Singer SDK to
 develop your own Singer taps and targets.
-
-
-## Minimal Permissions Required on DB2
-
-This library will perform the following actions on DB2.
-
-* CREATE TABLE
-* DROP TABLE
-* ALTER TABLE ADD COLUMN
-* ALTER TABLE ALTER COLUMN
-* INSERT INTO TABLE
-* MERGE INTO TABLE USING
-* [OPTIONALLY] CREATE SCHEMA
-
-_NOTE: `CREATE SCHEMA` is used to create a new schema where data will be loaded. If the stated target_schema, specified via `default_target_schema` exists, this library will not issue a `CREATE SCHEMA` command_
-
-## Known Limitations & Issues
-
-# Complex Data Structures (arrays & maps)
-
-Complex values such as `dict` or `list` will be json encoded and stored as `VARCHAR`. The `VARCHAR` column has a default size of 10000, and it is user configurable via the setting `varchar_size`.
-
-IBM Db2 allows VARCHAR columns up to 32704 bytes.
-
-This target currently does not write to CLOB fields, PRs welcome!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "target-db2"
-version = "0.1.1"
+version = "0.1.2"
 description = "`target-db2` is a Singer target for db2, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Haleemur Ali <haleemur@infostrux.com>"]


### PR DESCRIPTION
# Description

- Some small improvements to documentation
- The sdk version is updated to 0.39.1
- The sdk's `SQLConnector.get_column_add_ddl` is no longer overridden (as the logic was been implemented upstream) in [PR-2583](https://github.com/meltano/sdk/pull/2583) [line 1001](https://github.com/meltano/sdk/pull/2583/files#diff-db20b40a2eb1ac17938f49d9757779cdb9998129d7fc075a964d20096ddb4b48L1001)

closes: https://github.com/Infostrux-Solutions/target-db2/issues/17