### PR TITLE
(fix): Add REORG step after ALTER COLUMN

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ ignore = [
     "ANN102",  # missing-type-cls
     "COM812",  # missing-trailing-comma
     "ISC001",  # single-line-implicit-string-concatenation
+    "S608",    # Possible SQL injection vector through string-based query construction
 ]
 exclude = ["target_db2/ibm_db_sa"]
 select = ["ALL"]

--- a/tests/testdata/schema_change_to_numeric_multipleof.singer
+++ b/tests/testdata/schema_change_to_numeric_multipleof.singer
@@ -1,2 +1,6 @@
 {"type":"SCHEMA","stream":"test_schema_change_numeric_mulipleof","schema":{"properties":{"id":{"type":["integer"]},"val1":{"type":["number","null"]}},"type":"object","required":["id"]},"key_properties":["id"]}
+{"type": "RECORD","stream":"test_schema_change_numeric_mulipleof","record": {"id":1,"val1":10.00}}
+{"type": "RECORD","stream":"test_schema_change_numeric_mulipleof","record": {"id":2,"val1":20.00}}
+{"type": "RECORD","stream":"test_schema_change_numeric_mulipleof","record": {"id":3,"val1":30.00}}
 {"type":"SCHEMA","stream":"test_schema_change_numeric_mulipleof","schema":{"properties":{"id":{"type":["integer"]},"val1":{"type":["number","null"], "multipleOf": 0.01}},"type":"object","required":["id"]},"key_properties":["id"]}
+{"type": "RECORD","stream":"test_schema_change_numeric_mulipleof","record": {"id":1,"val1":10.25}}


### PR DESCRIPTION
# Description

Sometimes a Db2 table can enter a `REORG_PENDING` step, following an `ALTER COLUMN` statement.

After each `ALTER COLUMN` verify & perform a `REORG` operation if necessary